### PR TITLE
RSF related bug fixes.

### DIFF
--- a/autosac
+++ b/autosac
@@ -20,7 +20,7 @@ from lib.execute import execute, Retcode
 from lib.prompt import prompt_yn
 from lib.checks import *
 
-version = "1.0.1"
+version = "1.0.2"
 output_d = "/var/tmp/go-live"
 output_f = "nexenta-autosac-%s.json" \
                % time.strftime('%Y%m%d.%H%M%S', time.localtime(time.time()))

--- a/lib/config.py
+++ b/lib/config.py
@@ -433,7 +433,10 @@ def _get_rsf_services():
 
     # Parse each line of otput and split on ':'
     for l in output.splitlines():
-        svc, host = [x.strip() for x in output.split(":")]
+        # Skip empty lines
+        if not l.strip():
+            continue
+        svc, host = [x.strip() for x in l.split(":")]
         # Check if service is stopped
         if host == "-":
             host = None


### PR DESCRIPTION
@phart, @pwags and @papasteed please review ASAP.

There was an issue where each line of rsfcli list wasn't parsed so services wouldn't fail over properly.

```
Traceback (most recent call last):
  File "./autosac", line 174, in main
    data["results"][name] = f(*c["args"], **c["kwargs"])
  File "/root/fe/autosac/lib/checks.py", line 273, in check_rsf_failover
    name, partner, services = get_rsf_conf()
  File "/root/fe/autosac/lib/config.py", line 378, in get_rsf_conf
    services = _get_rsf_services()
  File "/root/fe/autosac/lib/config.py", line 436, in _get_rsf_services
    svc, host = [x.strip() for x in output.split(":")]
ValueError: too many values to unpack
```
