### PR TITLE
Fixes related to differences between 3.x and 4.x

### DIFF
--- a/autosac
+++ b/autosac
@@ -20,7 +20,7 @@ from lib.execute import execute, Retcode
 from lib.prompt import prompt_yn
 from lib.checks import *
 
-version = "1.1.0"
+version = "1.1.1"
 output_d = "/var/tmp/go-live"
 output_f = "nexenta-autosac-%s.json" \
                % time.strftime('%Y%m%d.%H%M%S', time.localtime(time.time()))

--- a/lib/config.py
+++ b/lib/config.py
@@ -486,10 +486,11 @@ def _get_rsf_partner():
         partner (str): Partner hostname
     """
     partner = None
+    hosts = []
     hostname = get_hostname()
 
     try:
-        output = execute("%s nodes" % _rsfcli)
+        output = execute("%s status" % _rsfcli)
     except Exception, e:
         logger.error("Failed to determine appliance RSF partner")
         logger.debug(str(e), exc_info=True)
@@ -497,11 +498,13 @@ def _get_rsf_partner():
 
     # Parse the output for the partner hostname
     for l in output.splitlines():
-        # Some versions of this command contain the '*' character at the end
-        # of line so we split on spaces
-        host = l.split()[0]
-        if host != hostname:
-            partner = host
+        if l.startswith("Host"):
+            hosts.append(l.split()[1].strip())
+
+    # Determine which clustered host is the partner
+    for h in hosts:
+        if h != hostname:
+            partner = h
             break
 
     if partner is None:

--- a/lib/diskqual.py
+++ b/lib/diskqual.py
@@ -8,6 +8,7 @@ William Kettler <william.kettler@nexenta.com>
 """
 
 import sys
+import os
 import time
 import subprocess
 import logging
@@ -31,7 +32,14 @@ def dd(ifile, ofile, bs, duration):
     Outputs:
         tput (int): Throughput in MB/s
     """
-    cmd = "/usr/gnu/bin/dd if=%s of=%s bs=%sK" % (ifile, ofile, bs)
+    dd = "/usr/gnu/bin/dd"
+
+    # Check that the dd command exists
+    # On 3.x the command is in a seperate location
+    if not os.path.isfile(dd):
+        raise RuntimeError("%s does not exist" % dd)
+
+    cmd = "%s if=%s of=%s bs=%sK" % (dd, ifile, ofile, bs)
 
     logger.debug("Executing \"%s\"" % cmd)
 


### PR DESCRIPTION
rsfcli nodes has been changed to rsfcli status due to differences in 3.x and 4.x that cause auotsac to fail to determine it's partners hostname. 
